### PR TITLE
chore(release): prepare v0.3.1 - first public release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-01-03
+
+### Added
+- Support for 32-bit float WAV files with automatic conversion to 16-bit PCM
+- Explicit error messages for unsupported WAV formats (non-16-bit PCM, non-32-bit float)
+
+### Changed
+- Audio loading errors now logged with tracing before exit instead of raw error output
+- Improved error context in WAV reading path
+
+### Fixed
+- Graceful error handling for incompatible audio file formats
+
 ## [0.3.0] - 2026-01-02
 
 **Phase 3: Observability - Metrics and Measurement Infrastructure**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "receiver"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -977,7 +977,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rtp-opus-common"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -1017,7 +1017,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sender"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["common", "sender", "receiver"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Your Name <your.email@example.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Prepare first release covering Phases 1-3 plus recent improvements.

This release includes:
- Phase 1: Core pipeline (WAV → RTP → playback)
- Phase 2: Network resilience (jitter buffer, loss handling)
- Phase 3: Observability (Prometheus metrics, tracing)
- 32-bit float WAV support and improved error handling

Phase 4 (adaptive behavior) deferred to future release.